### PR TITLE
Bug/armies declaring battles while in other battle

### DIFF
--- a/src/main/java/com/ardaslegends/domain/Army.java
+++ b/src/main/java/com/ardaslegends/domain/Army.java
@@ -1,5 +1,6 @@
 package com.ardaslegends.domain;
 
+import com.ardaslegends.domain.war.battle.Battle;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
@@ -96,6 +97,9 @@ public final class Army extends AbstractDomainObject {
 
     @Column(name = "is_paid")
     private Boolean isPaid;
+
+    @Column(name = "current_battle")
+    private Battle currentBattle;
 
     public Army(String name, ArmyType armyType, Faction faction, Region currentRegion, RPChar boundTo, List<Unit> units, List<String> sieges, ClaimBuild stationedAt, Double freeTokens, boolean isHealing, OffsetDateTime healStart, OffsetDateTime healEnd,
                 Integer hoursHealed, Integer hoursLeftHealing, ClaimBuild originalClaimbuild, OffsetDateTime createdAt, boolean isPaid) {

--- a/src/main/java/com/ardaslegends/domain/Army.java
+++ b/src/main/java/com/ardaslegends/domain/Army.java
@@ -1,6 +1,5 @@
 package com.ardaslegends.domain;
 
-import com.ardaslegends.domain.war.battle.Battle;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
@@ -97,9 +96,6 @@ public final class Army extends AbstractDomainObject {
 
     @Column(name = "is_paid")
     private Boolean isPaid;
-
-    @Column(name = "current_battle")
-    private Battle currentBattle;
 
     public Army(String name, ArmyType armyType, Faction faction, Region currentRegion, RPChar boundTo, List<Unit> units, List<String> sieges, ClaimBuild stationedAt, Double freeTokens, boolean isHealing, OffsetDateTime healStart, OffsetDateTime healEnd,
                 Integer hoursHealed, Integer hoursLeftHealing, ClaimBuild originalClaimbuild, OffsetDateTime createdAt, boolean isPaid) {

--- a/src/main/java/com/ardaslegends/domain/Faction.java
+++ b/src/main/java/com/ardaslegends/domain/Faction.java
@@ -51,6 +51,7 @@ public final class Faction extends AbstractDomainObject {
     @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "ownedBy")
     private List<ClaimBuild> claimBuilds; //all claimbuilds of this faction
     @ManyToMany(mappedBy = "usableBy")
+    @Builder.Default
     private Set<UnitType> availableUnits = new HashSet<>(15);
 
 
@@ -91,6 +92,7 @@ public final class Faction extends AbstractDomainObject {
         this.homeRegion = homeRegion;
         this.factionBuffDescr = factionBuffDescr;
         this.foodStockpile = 0;
+        this.availableUnits = new HashSet<>(15);
     }
 
     @JsonIgnore

--- a/src/main/java/com/ardaslegends/domain/UnitType.java
+++ b/src/main/java/com/ardaslegends/domain/UnitType.java
@@ -29,18 +29,21 @@ public final class UnitType extends AbstractDomainObject {
     private Double tokenCost; //how much tokens this unit costs
 
     @NotNull
+    @Builder.Default
     private Boolean isMounted = false;
 
     @ManyToMany
     @JoinTable(name = "factions_units",
             joinColumns = {@JoinColumn(name = "unit_name", foreignKey = @ForeignKey(name = "fk_factions_units_unit_name"))},
             inverseJoinColumns = {@JoinColumn(name = "faction_id", foreignKey = @ForeignKey(name = "fk_factions_units_faction_id"))})
+    @Builder.Default
     private Set<Faction> usableBy = new HashSet<>(2);
 
     public UnitType(String unitName, Double tokenCost, Boolean isMounted) {
         this.unitName = unitName;
         this.tokenCost = tokenCost;
         this.isMounted = isMounted;
+        this.usableBy = new HashSet<>(2);
     }
 
     @Override

--- a/src/main/java/com/ardaslegends/domain/war/battle/Battle.java
+++ b/src/main/java/com/ardaslegends/domain/war/battle/Battle.java
@@ -5,13 +5,11 @@ import com.ardaslegends.domain.AbstractDomainObject;
 import com.ardaslegends.domain.Army;
 import com.ardaslegends.domain.Faction;
 import com.ardaslegends.domain.war.War;
-import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import jakarta.persistence.*;
 import lombok.Setter;
 
 import java.time.OffsetDateTime;
@@ -34,16 +32,16 @@ public class Battle extends AbstractDomainObject {
 
     @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinTable(name = "wars_battles",
-            joinColumns = { @JoinColumn(name = "battle_id", foreignKey = @ForeignKey(name = "fk_wars_battles_battle_id"))},
-            inverseJoinColumns = { @JoinColumn(name = "war_id", foreignKey = @ForeignKey(name = "fk_wars_battles_war_id")) })
+            joinColumns = {@JoinColumn(name = "battle_id", foreignKey = @ForeignKey(name = "fk_wars_battles_battle_id"))},
+            inverseJoinColumns = {@JoinColumn(name = "war_id", foreignKey = @ForeignKey(name = "fk_wars_battles_war_id"))})
     private Set<War> wars;
 
     private String name;
 
     @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinTable(name = "battle_attackingArmies",
-            joinColumns = { @JoinColumn(name = "battle_id", foreignKey = @ForeignKey(name = "fk_battle_attackingArmies_battle"))},
-            inverseJoinColumns = { @JoinColumn(name = "atackingArmy_id", foreignKey = @ForeignKey(name = "fk_battle_attackingArmies_attackingArmy")) })
+            joinColumns = {@JoinColumn(name = "battle_id", foreignKey = @ForeignKey(name = "fk_battle_attackingArmies_battle"))},
+            inverseJoinColumns = {@JoinColumn(name = "atackingArmy_id", foreignKey = @ForeignKey(name = "fk_battle_attackingArmies_attackingArmy"))})
     private Set<Army> attackingArmies = new HashSet<>(1);
 
     @NotNull
@@ -57,11 +55,12 @@ public class Battle extends AbstractDomainObject {
 
     @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinTable(name = "battle_defendingArmies",
-            joinColumns = { @JoinColumn(name = "battle_id", foreignKey = @ForeignKey(name = "fk_battle_defendingArmies_battle"))},
-            inverseJoinColumns = { @JoinColumn(name = "defendingArmy_id", foreignKey = @ForeignKey(name = "fk_battle_defendingArmies_defendingArmy")) })
+            joinColumns = {@JoinColumn(name = "battle_id", foreignKey = @ForeignKey(name = "fk_battle_defendingArmies_battle"))},
+            inverseJoinColumns = {@JoinColumn(name = "defendingArmy_id", foreignKey = @ForeignKey(name = "fk_battle_defendingArmies_defendingArmy"))})
     private Set<Army> defendingArmies = new HashSet<>();
 
     @Setter
+    @Enumerated(EnumType.STRING)
     private BattlePhase battlePhase;
 
     private OffsetDateTime declaredDate;
@@ -93,7 +92,7 @@ public class Battle extends AbstractDomainObject {
         this.agreedBattleDate = agreedBattleDate;
         this.battleLocation = battleLocation;
         this.initialAttacker = attackingArmies.stream().findFirst().orElseThrow(() -> new IllegalArgumentException("CONTACT DEVS: No initial attacker in Battle %s!".formatted(name)));
-        if(battleLocation.getFieldBattle())
+        if (battleLocation.getFieldBattle())
             this.initialDefender = defendingArmies.stream().findFirst().orElseThrow(() -> new IllegalArgumentException("CONTACT DEVS: No initial defender in Battle %s!".formatted(name))).getFaction();
         else
             this.initialDefender = battleLocation.getClaimBuild().getOwnedBy();
@@ -110,6 +109,12 @@ public class Battle extends AbstractDomainObject {
         return defendingArmies.stream().findFirst()
                 .orElseThrow(() -> new NullPointerException("Found no defending armies in battle at location %s".formatted(battleLocation.toString())));
     }
-    public boolean isOver() { return BattlePhase.CONCLUDED.equals(this.battlePhase); }
-    public boolean isFieldBattle() {return battleLocation.getFieldBattle();}
+
+    public boolean isOver() {
+        return BattlePhase.CONCLUDED.equals(this.battlePhase);
+    }
+
+    public boolean isFieldBattle() {
+        return battleLocation.getFieldBattle();
+    }
 }

--- a/src/main/java/com/ardaslegends/repository/war/battle/BattleRepository.java
+++ b/src/main/java/com/ardaslegends/repository/war/battle/BattleRepository.java
@@ -2,6 +2,16 @@ package com.ardaslegends.repository.war.battle;
 
 import com.ardaslegends.domain.war.battle.Battle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Set;
 
 public interface BattleRepository extends JpaRepository<Battle, Long>, BattleRepositoryCustom {
+    @Query("SELECT b FROM Battle b JOIN b.attackingArmies a JOIN b.defendingArmies d WHERE (a.id = :armyId OR d.id = :armyId) AND b.battlePhase <> 'CONCLUDED'")
+    Battle findActiveBattleByArmyId(@Param("armyId") Long armyId);
+
+    @Query("SELECT b FROM Battle b JOIN b.attackingArmies a JOIN b.defendingArmies d WHERE (a.id = :armyId OR d.id = :armyId) AND b.battlePhase = 'CONCLUDED'")
+    Set<Battle> findPastBattlesByArmyId(@Param("armyId") Long armyId);
+
 }

--- a/src/main/java/com/ardaslegends/service/exceptions/logic/war/BattleServiceException.java
+++ b/src/main/java/com/ardaslegends/service/exceptions/logic/war/BattleServiceException.java
@@ -21,29 +21,78 @@ public class BattleServiceException extends LogicException {
     private static final String ARMY_DOES_NOT_CONTAIN_UNIT = "Army '%s' does not contain unit '%s'!";
     private static final String UNIT_NEW_AMOUNT_TOO_LARGE = "Army '%s' only had %d '%s' before the battle!";
     private static final String UNIT_NEW_AMOUNT_NEGATIVE = "New '%s' amount cannot be negative (%d)!";
+    private static final String ARMY_ALREADY_IN_BATTLE = "Army '%s' is already in battle!";
 
-    public static BattleServiceException factionsNotAtWar(String factionName1, String factionName2) { return new BattleServiceException(FACTIONS_NOT_AT_WAR.formatted(factionName1, factionName2)); }
-
-    public static BattleServiceException battleNotAbleDueHours (){ return  new BattleServiceException(BATTLE_NOT_ABLE_DUE_HOURS.formatted());}
-    public static BattleServiceException defendingArmyIsMovingAway (Army armyMovingAway){
-        val durationUntilNextRegion = armyMovingAway.getActiveMovement().orElseThrow(() -> new IllegalArgumentException("Army %s has no movement! PLEASE CONTACT DEVS".formatted(armyMovingAway.getName()))).getDurationUntilNextRegion();
-        return new BattleServiceException(DEFENDING_ARMY_IS_MOVING_AWAY.formatted(ServiceUtils.formatDuration(durationUntilNextRegion)));}
-    public static BattleServiceException attackingArmyHasAnotherMovement(){return new BattleServiceException(ATTACKING_ARMY_HAS_ANOTHER_MOVEMENT.formatted());}
-    public static BattleServiceException notEnoughHealth(){ return new BattleServiceException(NOT_ENOUGH_HEALTH.formatted());}
-    public static BattleServiceException notInSameRegion(Army attacker, Army defender){ return new BattleServiceException(NOT_IN_SAME_REGION.formatted(defender.getName(), attacker.getName()));}
-    public static BattleServiceException cannotAttackStarterHamlet() {return new BattleServiceException(CANNOT_ATTACK_STARTER_HAMLET);}
-    public static BattleServiceException noPlayerBound(String armyName) {return new BattleServiceException(NO_PLAYER_BOUND.formatted(armyName));}
-    public static BattleServiceException armyYoungerThan24h(String armyName) {return new BattleServiceException(ARMY_YOUNGER_THAN_24H.formatted(armyName));}
-    public static BattleServiceException factionNotPartOfBattle(String factionName, Long battleId) {return new BattleServiceException(FACTION_NOT_PART_IN_BATTLE.formatted(factionName, battleId));}
-    public static BattleServiceException armyNotPartOfBattle(String armyName, Long battleId) {return new BattleServiceException(ARMY_NOT_PART_IN_BATTLE.formatted(armyName, battleId));}
-    public static BattleServiceException battleAlreadyConcluded() {return new BattleServiceException(BATTLE_ALREADY_CONCLUDED);}
-    public static BattleServiceException armyDoesNotContainUnit(String armyName, String unitName) {return new BattleServiceException(ARMY_DOES_NOT_CONTAIN_UNIT.formatted(armyName, unitName));}
-    public static BattleServiceException newUnitAmountTooLarge(String armyName, Integer amountBeforeBattle, String unitName) {return new BattleServiceException(UNIT_NEW_AMOUNT_TOO_LARGE.formatted(armyName, amountBeforeBattle, unitName));}
-    public static BattleServiceException newUnitAmountNegative(String unitName, Integer newAmount) {return new BattleServiceException(UNIT_NEW_AMOUNT_NEGATIVE.formatted(unitName, newAmount));}
     protected BattleServiceException(String message, Throwable rootCause) {
         super(message, rootCause);
     }
+
     protected BattleServiceException(String message) {
         super(message);
+    }
+
+    public static BattleServiceException factionsNotAtWar(String factionName1, String factionName2) {
+        return new BattleServiceException(FACTIONS_NOT_AT_WAR.formatted(factionName1, factionName2));
+    }
+
+    public static BattleServiceException battleNotAbleDueHours() {
+        return new BattleServiceException(BATTLE_NOT_ABLE_DUE_HOURS.formatted());
+    }
+
+    public static BattleServiceException defendingArmyIsMovingAway(Army armyMovingAway) {
+        val durationUntilNextRegion = armyMovingAway.getActiveMovement().orElseThrow(() -> new IllegalArgumentException("Army %s has no movement! PLEASE CONTACT DEVS".formatted(armyMovingAway.getName()))).getDurationUntilNextRegion();
+        return new BattleServiceException(DEFENDING_ARMY_IS_MOVING_AWAY.formatted(ServiceUtils.formatDuration(durationUntilNextRegion)));
+    }
+
+    public static BattleServiceException attackingArmyHasAnotherMovement() {
+        return new BattleServiceException(ATTACKING_ARMY_HAS_ANOTHER_MOVEMENT.formatted());
+    }
+
+    public static BattleServiceException notEnoughHealth() {
+        return new BattleServiceException(NOT_ENOUGH_HEALTH.formatted());
+    }
+
+    public static BattleServiceException notInSameRegion(Army attacker, Army defender) {
+        return new BattleServiceException(NOT_IN_SAME_REGION.formatted(defender.getName(), attacker.getName()));
+    }
+
+    public static BattleServiceException cannotAttackStarterHamlet() {
+        return new BattleServiceException(CANNOT_ATTACK_STARTER_HAMLET);
+    }
+
+    public static BattleServiceException noPlayerBound(String armyName) {
+        return new BattleServiceException(NO_PLAYER_BOUND.formatted(armyName));
+    }
+
+    public static BattleServiceException armyYoungerThan24h(String armyName) {
+        return new BattleServiceException(ARMY_YOUNGER_THAN_24H.formatted(armyName));
+    }
+
+    public static BattleServiceException factionNotPartOfBattle(String factionName, Long battleId) {
+        return new BattleServiceException(FACTION_NOT_PART_IN_BATTLE.formatted(factionName, battleId));
+    }
+
+    public static BattleServiceException armyNotPartOfBattle(String armyName, Long battleId) {
+        return new BattleServiceException(ARMY_NOT_PART_IN_BATTLE.formatted(armyName, battleId));
+    }
+
+    public static BattleServiceException battleAlreadyConcluded() {
+        return new BattleServiceException(BATTLE_ALREADY_CONCLUDED);
+    }
+
+    public static BattleServiceException armyDoesNotContainUnit(String armyName, String unitName) {
+        return new BattleServiceException(ARMY_DOES_NOT_CONTAIN_UNIT.formatted(armyName, unitName));
+    }
+
+    public static BattleServiceException newUnitAmountTooLarge(String armyName, Integer amountBeforeBattle, String unitName) {
+        return new BattleServiceException(UNIT_NEW_AMOUNT_TOO_LARGE.formatted(armyName, amountBeforeBattle, unitName));
+    }
+
+    public static BattleServiceException newUnitAmountNegative(String unitName, Integer newAmount) {
+        return new BattleServiceException(UNIT_NEW_AMOUNT_NEGATIVE.formatted(unitName, newAmount));
+    }
+
+    public static BattleServiceException armyAlreadyInBattle(String armyName) {
+        return new BattleServiceException(ARMY_ALREADY_IN_BATTLE.formatted(armyName));
     }
 }

--- a/src/main/java/com/ardaslegends/service/war/BattleService.java
+++ b/src/main/java/com/ardaslegends/service/war/BattleService.java
@@ -2,19 +2,19 @@ package com.ardaslegends.service.war;
 
 import com.ardaslegends.domain.*;
 import com.ardaslegends.domain.war.battle.*;
-import com.ardaslegends.repository.war.WarRepository;
 import com.ardaslegends.repository.war.QueryWarStatus;
+import com.ardaslegends.repository.war.WarRepository;
 import com.ardaslegends.repository.war.battle.BattleRepository;
 import com.ardaslegends.service.*;
-import com.ardaslegends.service.dto.war.battle.ConcludeBattleDto;
-import com.ardaslegends.service.dto.war.battle.RpCharCasualtyDto;
-import com.ardaslegends.service.dto.war.battle.SurvivingUnitsDto;
-import com.ardaslegends.service.dto.war.battle.CreateBattleDto;
 import com.ardaslegends.service.discord.DiscordService;
 import com.ardaslegends.service.discord.messages.war.BattleMessages;
+import com.ardaslegends.service.dto.war.battle.ConcludeBattleDto;
+import com.ardaslegends.service.dto.war.battle.CreateBattleDto;
+import com.ardaslegends.service.dto.war.battle.RpCharCasualtyDto;
+import com.ardaslegends.service.dto.war.battle.SurvivingUnitsDto;
+import com.ardaslegends.service.exceptions.logic.army.ArmyServiceException;
 import com.ardaslegends.service.exceptions.logic.rpchar.RpCharServiceException;
 import com.ardaslegends.service.exceptions.logic.war.BattleServiceException;
-import com.ardaslegends.service.exceptions.logic.army.ArmyServiceException;
 import com.ardaslegends.service.time.TimeFreezeService;
 import com.ardaslegends.service.utils.ServiceUtils;
 import lombok.RequiredArgsConstructor;
@@ -58,7 +58,7 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
         Army attackingArmy = armyService.getArmyByName(createBattleDto.attackingArmyName());
 
         log.debug("Checking if army is older than 24h");
-        if(attackingArmy.isYoungerThan24h()) {
+        if (attackingArmy.isYoungerThan24h()) {
             log.warn("Army [{}] cannot declare battle because it was created less than 24h ago!", attackingArmy.getName());
             throw BattleServiceException.armyYoungerThan24h(attackingArmy.getName());
         }
@@ -70,21 +70,27 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
         }
 
         log.debug("Checking if army has a player bound to it");
-        if(attackingArmy.getBoundTo() == null) {
+        if (attackingArmy.getBoundTo() == null) {
             log.warn("Cannot declare battle because attacking army [{}] is not bound to a player", attackingArmy.getName());
             throw BattleServiceException.noPlayerBound(attackingArmy.getName());
         }
 
         log.debug("Checking if army has enough health to start the battle");
-        if(attackingArmy.getFreeTokens() <=0 ){
+        if (attackingArmy.getFreeTokens() <= 0) {
             log.warn("The attacking army: [{}] can not start a battle, because they don`t have enough health!", attackingArmy);
             throw BattleServiceException.notEnoughHealth();
         }
 
         log.debug("Checking if attacking army is currently in a movement");
-        if(attackingArmy.getActiveMovement().isPresent()){
+        if (attackingArmy.getActiveMovement().isPresent()) {
             log.warn("Attacking army is currently moving, cannot declare battle!");
             throw BattleServiceException.attackingArmyHasAnotherMovement();
+        }
+
+        log.debug("Checking if attacking army is currently in a battle or has already declared a battle");
+        if (attackingArmy.getCurrentBattle() != null) {
+            log.warn("Attacking army is currently in a battle, cannot declare battle!");
+            throw BattleServiceException.armyAlreadyInBattle(attackingArmy.getName());
         }
 
         log.debug("Setting attacking faction to: [{}]", attackingArmy.getFaction().getName());
@@ -96,7 +102,7 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
         Set<Army> defendingArmies = new HashSet<>();
         List<PathElement> path;
 
-        if(createBattleDto.isFieldBattle()){
+        if (createBattleDto.isFieldBattle()) {
             log.debug("Declared battle is field battle");
             log.debug("Fetching single defending army with name: [{}]", createBattleDto.defendingArmyName());
             log.trace("Calling getArmyByName with name: [{}]", createBattleDto.defendingArmyName());
@@ -109,18 +115,18 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
             log.debug("Attacking army region: [{}]", attackerRegion);
             log.debug("Defending army region: [{}]", defenderRegion);
 
-            if(!defenderRegion.equals(attackerRegion)) {
+            if (!defenderRegion.equals(attackerRegion)) {
                 log.warn("Attacking army is not in the same region [{}] as defending army [{}]", attackerRegion, defenderRegion);
                 throw BattleServiceException.notInSameRegion(attackingArmy, defendingArmy);
             }
 
             log.debug("Checking if defending army is moving away");
-            if(defendingArmy.getActiveMovement().isPresent()) {
+            if (defendingArmy.getActiveMovement().isPresent()) {
                 var activeMovement = defendingArmy.getActiveMovement().get();
                 log.debug("Defending army [{}] is moving [{}]", defendingArmy, activeMovement);
                 log.debug("Next region: [{}] - Duration until next region: [{}]", activeMovement.getNextRegion(), ServiceUtils.formatDuration(activeMovement.getDurationUntilNextRegion()));
 
-                if(activeMovement.getDurationUntilNextRegion().minusHours(24).isNegative()) {
+                if (activeMovement.getDurationUntilNextRegion().minusHours(24).isNegative()) {
                     log.debug("Next region is reached in <= 24h");
                     log.warn("Cannot declare battle - defending army cannot be reached because it is moving away in [{}]!", ServiceUtils.formatDuration(activeMovement.getDurationUntilNextRegion()));
                     throw BattleServiceException.defendingArmyIsMovingAway(defendingArmy);
@@ -133,8 +139,7 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
             log.debug("Setting defending Faction to: [{}]", defendingArmy.getFaction().getName());
             defendingFaction = defendingArmy.getFaction();
             battleRegion = defendingArmy.getCurrentRegion();
-        }
-        else {
+        } else {
             log.debug("Declared battle is claimbuild battle");
             log.debug("Fetching all stationed armies at claimbuild: [{}]", createBattleDto.claimBuildName());
             log.trace("Calling getClaimBuildByName with name: [{}]", createBattleDto.claimBuildName());
@@ -144,29 +149,28 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
             List<Army> stationedArmies = attackedClaimbuild.getStationedArmies();
 
             log.debug("Checking if claimbuild [{}] is starter hamlet of faction [{}]", attackedClaimbuild.getName(), defendingFaction.getName());
-            if(attackedClaimbuild.getName().toLowerCase().endsWith("starter hamlet")) {
+            if (attackedClaimbuild.getName().toLowerCase().endsWith("starter hamlet")) {
                 log.warn("Cannot declare battle on clamibuild [{}] because it is the starter hamlet of faction [{}]", attackedClaimbuild.getName(), defendingFaction.getName());
                 throw BattleServiceException.cannotAttackStarterHamlet();
             }
 
 
-            if(!attackingArmy.getCurrentRegion().equals(attackedClaimbuild.getRegion())) {
+            if (!attackingArmy.getCurrentRegion().equals(attackedClaimbuild.getRegion())) {
                 log.debug("Army is not in region of claimbuild");
                 log.debug("Calling pathfinder to find shortest way from regions [{}] to [{}]", attackingArmy.getCurrentRegion(), battleRegion);
-                path = pathfinder.findShortestWay(attackingArmy.getCurrentRegion(), attackedClaimbuild.getRegion(),executorPlayer,true);
+                path = pathfinder.findShortestWay(attackingArmy.getCurrentRegion(), attackedClaimbuild.getRegion(), executorPlayer, true);
                 log.debug("Path: [{}], duration: [{} days]", ServiceUtils.buildPathString(path), ServiceUtils.getTotalPathCost(path));
 
                 log.debug("Checking if claimbuild is reachable in 24 hours");
-                if(ServiceUtils.getTotalPathCost(path) > 24){
+                if (ServiceUtils.getTotalPathCost(path) > 24) {
                     log.warn("Cannot declare battle - Claimbuild [{}] is not in 24 hour reach of attacking army [{}]", attackedClaimbuild.getName(), attackingArmy.getName());
                     throw BattleServiceException.battleNotAbleDueHours();
                 }
-            }
-            else
+            } else
                 log.debug("Army [{}] is already in region [{}] of Claimbuild [{}]", attackingArmy.getName(), attackingArmy.getCurrentRegion().getId(), attackedClaimbuild.getName());
 
 
-            if(stationedArmies.isEmpty())
+            if (stationedArmies.isEmpty())
                 log.debug("No armies stationed at claim build with name: [{}]", createBattleDto.claimBuildName());
             else {
                 log.debug("[{}] armies stationed at claim build with name: [{}]", stationedArmies.size(), createBattleDto.claimBuildName());
@@ -175,7 +179,7 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
         }
 
         val wars = warRepository.queryWarsBetweenFactions(attackingFaction, defendingFaction, QueryWarStatus.ACTIVE);
-        if(wars.isEmpty()){
+        if (wars.isEmpty()) {
             log.warn("Cannot create battle: The attacking faction [{}] and the defending faction [{}] are not at war with each other", attackingFaction.getName(), defendingFaction.getName());
             throw BattleServiceException.factionsNotAtWar(attackingFaction.getName(), defendingFaction.getName());
         }
@@ -206,8 +210,7 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
         log.debug("Trying to persist the battle object");
         try {
             battle = secureSave(createdBattle, battleRepository);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             log.warn("Cancelling 24h timer since there was an error while persisting battle [{}]", createdBattle);
             timer.future().cancel(true);
             throw e;
@@ -255,7 +258,7 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
         log.debug("Finding battle with id [{}]", concludeBattleDto.battleId());
         val battle = battleRepository.queryByIdOrElseThrow(concludeBattleDto.battleId());
 
-        if(battle.getBattleResult().isPresent()) {
+        if (battle.getBattleResult().isPresent()) {
             log.warn("Battle [{}] already has a result [{}]", battle.getId(), battle.getBattleResult());
             throw BattleServiceException.battleAlreadyConcluded();
         }
@@ -270,14 +273,14 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
                 .anyMatch(faction -> faction.equals(winnerFaction));
         log.debug("Winner is on attacking side: [{}]", isWinnerOnAttackerSide);
 
-        if(!isWinnerOnAttackerSide) {
+        if (!isWinnerOnAttackerSide) {
             log.debug("Looking if winner faction [{}] is on defending side", winnerFaction.getName());
             val isWinnerOnDefendingSide = battle.getDefendingArmies().stream()
                     .map(Army::getFaction)
                     .anyMatch(faction -> faction.equals(winnerFaction));
             log.debug("Winner is on defending side: [{}]", isWinnerOnDefendingSide);
 
-            if(!isWinnerOnDefendingSide) {
+            if (!isWinnerOnDefendingSide) {
                 log.warn("Faction [{}] is not part of battle [{}]", winnerFaction.getName(), battle.getId());
                 throw BattleServiceException.factionNotPartOfBattle(winnerFaction.getName(), battle.getId());
             }
@@ -326,11 +329,11 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
         battle.setTimeFrozenUntil(now);
 
         log.debug("Checking if claimbuild ownership needs to be changed");
-        if(!battle.isFieldBattle()) {
+        if (!battle.isFieldBattle()) {
             val claimbuild = battle.getBattleLocation().getClaimBuild();
             log.debug("Battle is claimbuild battle");
             log.debug("Checking if old owner [{}] is different from battle winner [{}]", claimbuild.getOwnedBy().getName(), battleResult.getWinner().getName());
-            if(!claimbuild.getOwnedBy().equals(battleResult.getWinner())) {
+            if (!claimbuild.getOwnedBy().equals(battleResult.getWinner())) {
                 log.debug("Old owner is different than battle winner - setting new owner to [{}]", battleResult.getWinner().getName());
                 claimBuildService.changeOwner(claimbuild, battleResult.getWinner());
             }
@@ -365,7 +368,8 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
     /**
      * Updates the units of the army specified in the SurvivingUnitsDto to only include the surviving
      * units also specified in the dto
-     * @param dto Dto which contains the army and its surviving units
+     *
+     * @param dto    Dto which contains the army and its surviving units
      * @param battle The battle which the casualties happened in
      * @return A set of UnitCasualty objects of the units that died in the battle.
      */
@@ -377,7 +381,7 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
                 .filter(army -> army.getName().equals(dto.army()))
                 .findFirst();
 
-        if(foundArmy.isEmpty()) {
+        if (foundArmy.isEmpty()) {
             log.warn("No army with name [{}] found in battle [{}]!", dto.army(), battle);
             throw BattleServiceException.armyNotPartOfBattle(dto.army(), battle.getId());
         }
@@ -394,7 +398,7 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
             log.debug("Checking if unit [{}] is present in army [{}]", unitDto.unitTypeName(), army.getName());
             val foundUnit = units.stream().filter(unit -> unit.getUnitType().getUnitName().equals(unitDto.unitTypeName())).findFirst();
 
-            if(foundUnit.isEmpty()) {
+            if (foundUnit.isEmpty()) {
                 log.warn("Army [{}] does not contain unit [{}]!", army.getName(), unitDto.unitTypeName());
                 throw BattleServiceException.armyDoesNotContainUnit(army.getName(), unitDto.unitTypeName());
             }
@@ -406,12 +410,12 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
             val newAmount = unitDto.amount();
             log.debug("New amount alive of [{}]: [{}]", unitDto.unitTypeName(), newAmount);
 
-            if(newAmount < 0) {
+            if (newAmount < 0) {
                 log.warn("New amount [{}] is <0", newAmount);
                 throw BattleServiceException.newUnitAmountNegative(unitDto.unitTypeName(), newAmount);
             }
 
-            if(newAmount > oldAmount) {
+            if (newAmount > oldAmount) {
                 log.warn("New amount alive [{}] is larger than old amount alive [{}] for unit [{}]!", newAmount, oldAmount, unitDto.unitTypeName());
                 throw BattleServiceException.newUnitAmountTooLarge(army.getName(), oldAmount, unitDto.unitTypeName());
             }
@@ -419,7 +423,7 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
             val unitsLost = (long) (oldAmount - newAmount);
             log.debug("Amount of [{}] lost in battle: [{}]", unitDto.unitTypeName(), unitsLost);
 
-            if(unitsLost > 0) {
+            if (unitsLost > 0) {
                 log.debug("Amount lost is >0 -> creating UnitCasualty");
                 val unitCasualty = new UnitCasualty(unit, unitsLost);
 
@@ -439,7 +443,8 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
 
     /**
      * Kills all the units in the army and returns a set of UnitCasualties for all the units
-     * @param army Army which units should be killed
+     *
+     * @param army   Army which units should be killed
      * @param battle The battle which the casualties happened in
      * @return A set of UnitCasualty objects of the units that died in the battle.
      */
@@ -466,6 +471,7 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
 
     /**
      * Injures every RpChar of the players passed in the DiscordIdDto array.
+     *
      * @param dtos Array of discord id dtos of the players that died in the battle
      * @return A Set of RpCharCasualties for every injured RpChar
      * @throws RpCharServiceException noActiveRpChar When player has no RpChar
@@ -480,7 +486,7 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
             val player = playerService.getPlayerByDiscordId(dto.discordId());
             val activeChar = player.getActiveCharacter();
 
-            if(activeChar.isEmpty()) {
+            if (activeChar.isEmpty()) {
                 log.warn("Player [{}] has no active rpChar that can be injured!", player.getIgn());
                 throw RpCharServiceException.noActiveRpChar(player.getIgn());
             }
@@ -492,23 +498,21 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
 
             log.debug("Creating RpCharCasualty");
             RpCharCasualty casualty;
-            if(StringUtils.isNotBlank((dto.slainByPlayer()))) {
+            if (StringUtils.isNotBlank((dto.slainByPlayer()))) {
                 log.debug("dto.slainByPlayer is set to [{} - fetching slainByPlayer]", dto.slainByPlayer());
                 val slainByPlayer = playerService.getPlayerByDiscordId(dto.slainByPlayer());
 
                 String weapon = null;
-                if(StringUtils.isNotBlank(dto.slainByWeapon())) {
+                if (StringUtils.isNotBlank(dto.slainByWeapon())) {
                     log.debug("dto.slainByWeapon is set to [{}] - additionally adding weapon", dto.slainByWeapon());
                     weapon = dto.slainByWeapon();
                 }
 
                 casualty = new RpCharCasualty(rpChar, slainByPlayer, weapon);
-            }
-            else if (StringUtils.isNotBlank(dto.optionalCause())) {
+            } else if (StringUtils.isNotBlank(dto.optionalCause())) {
                 log.debug("No slainByPlayer set - using optionalCause");
                 casualty = new RpCharCasualty(rpChar, dto.optionalCause());
-            }
-            else {
+            } else {
                 log.debug("No death cause specified");
                 casualty = new RpCharCasualty(rpChar);
             }

--- a/src/test/java/com/ardaslegends/service/BattleServiceTest.java
+++ b/src/test/java/com/ardaslegends/service/BattleServiceTest.java
@@ -1,14 +1,14 @@
 package com.ardaslegends.service;
 
 import com.ardaslegends.domain.*;
-import com.ardaslegends.domain.war.battle.Battle;
-import com.ardaslegends.domain.war.battle.BattleLocation;
 import com.ardaslegends.domain.war.War;
 import com.ardaslegends.domain.war.WarParticipant;
-import com.ardaslegends.repository.war.battle.BattleRepository;
+import com.ardaslegends.domain.war.battle.Battle;
+import com.ardaslegends.domain.war.battle.BattleLocation;
 import com.ardaslegends.repository.war.WarRepository;
-import com.ardaslegends.service.dto.war.battle.CreateBattleDto;
+import com.ardaslegends.repository.war.battle.BattleRepository;
 import com.ardaslegends.service.discord.DiscordService;
+import com.ardaslegends.service.dto.war.battle.CreateBattleDto;
 import com.ardaslegends.service.exceptions.logic.army.ArmyServiceException;
 import com.ardaslegends.service.exceptions.logic.war.BattleServiceException;
 import com.ardaslegends.service.time.TimeFreezeService;
@@ -29,43 +29,38 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Slf4j
 public class BattleServiceTest {
+    Set<Army> attackingArmies;
+    Set<Army> defendingArmies;
+    CreateBattleDto createBattleDto;
     private WarRepository mockWarRepository;
+    private BattleRepository mockBattleRepository;
     private BattleService battleService;
-
     private Faction faction1;
     private Faction faction2;
-
     private RPChar rpchar2;
-
     private Player player1;
-
     private Army army1;
     private Army army2;
-
     private War war;
-    private  WarParticipant warParticipant2;
-
+    private WarParticipant warParticipant2;
     private BattleLocation battleLocation;
-
     private Region region1;
     private Region region2;
     private ClaimBuild claimBuild2;
     private Movement movement;
+    private Battle battle;
 
-    Set<Army> attackingArmies;
-    Set<Army> defendingArmies;
-
-    CreateBattleDto createBattleDto;
     @BeforeEach
-    void setup(){
-        BattleRepository mockBattleRepository = mock(BattleRepository.class);
+    void setup() {
         mockWarRepository = mock(WarRepository.class);
+        mockBattleRepository = mock(BattleRepository.class);
         Pathfinder pathfinder = mock(Pathfinder.class);
         ArmyService mockArmyService = mock(ArmyService.class);
         PlayerService mockPlayerService = mock(PlayerService.class);
@@ -77,8 +72,7 @@ public class BattleServiceTest {
         User mockUser1 = mock(User.class);
         User mockUser2 = mock(User.class);
         Role mockRole = mock(Role.class);
-        battleService = new BattleService(mockBattleRepository, mockArmyService, mockPlayerService, mockRpCharService, mockClaimBuildService,mockWarRepository, pathfinder, mockFactionService, mockTimeFreezeService, mockDiscordService);
-
+        battleService = new BattleService(mockBattleRepository, mockArmyService, mockPlayerService, mockRpCharService, mockClaimBuildService, mockWarRepository, pathfinder, mockFactionService, mockTimeFreezeService, mockDiscordService);
         region1 = Region.builder().id("90").neighboringRegions(new HashSet<>()).regionType(RegionType.LAND).build();
         region2 = Region.builder().id("91").neighboringRegions(new HashSet<>()).regionType(RegionType.HILL).build();
         Region region3 = Region.builder().id("92").neighboringRegions(new HashSet<>()).regionType(RegionType.LAND).build();
@@ -134,9 +128,9 @@ public class BattleServiceTest {
         defendingArmies = new HashSet<>();
         defendingArmies.add(army2);
 
-        battleLocation = new BattleLocation(region2,true, null);
+        battleLocation = new BattleLocation(region2, true, null);
 
-        Battle battle = new Battle(new HashSet<>(Set.of(war)), "Battle of Gondor", attackingArmies, defendingArmies, OffsetDateTime.now(), OffsetDateTime.of(2023, 9, 20, 0, 0, 0, 0, ZoneOffset.UTC), OffsetDateTime.of(2023, 9, 30, 0, 0, 0, 0, ZoneOffset.UTC), OffsetDateTime.of(2023, 9, 20, 0, 0, 0, 0, ZoneOffset.UTC), battleLocation);
+        battle = new Battle(new HashSet<>(Set.of(war)), "Battle of Gondor", attackingArmies, defendingArmies, OffsetDateTime.now(), OffsetDateTime.of(2023, 9, 20, 0, 0, 0, 0, ZoneOffset.UTC), OffsetDateTime.of(2023, 9, 30, 0, 0, 0, 0, ZoneOffset.UTC), OffsetDateTime.of(2023, 9, 20, 0, 0, 0, 0, ZoneOffset.UTC), battleLocation);
 
         PathElement pathElement1 = PathElement.builder().region(region1).baseCost(region1.getCost()).actualCost(0).build();
         PathElement pathElement2 = PathElement.builder().region(region2).baseCost(region2.getCost()).actualCost(region2.getCost()).build();
@@ -144,10 +138,10 @@ public class BattleServiceTest {
         List<PathElement> path = List.of(pathElement2, pathElement1);
 
         val now = OffsetDateTime.now();
-        movement =  Movement.builder().isCharMovement(false).startTime(now.minusHours(2)).reachesNextRegionAt(now.plusHours(46)).endTime(now.plusHours(46)).isCurrentlyActive(true).army(army1).path(path).build();
+        movement = Movement.builder().isCharMovement(false).startTime(now.minusHours(2)).reachesNextRegionAt(now.plusHours(46)).endTime(now.plusHours(46)).isCurrentlyActive(true).army(army1).path(path).build();
 
-        createBattleDto = new CreateBattleDto("1234","Battle of Gondor","Knights of Gondor",
-                "Knights of Isengard",true,null);
+        createBattleDto = new CreateBattleDto("1234", "Battle of Gondor", "Knights of Gondor",
+                "Knights of Isengard", true, null);
 
         when(mockPlayerService.getPlayerByDiscordId(any())).thenReturn(player1);
         when(mockArmyService.getArmyByName(any())).thenReturn(army1);
@@ -159,12 +153,12 @@ public class BattleServiceTest {
         when(mockUser1.getMentionTag()).thenReturn(player1.getIgn());
         when(mockUser2.getMentionTag()).thenReturn(player2.getIgn());
         when(mockRole.getMentionTag()).thenReturn("RoleMentionTag");
-        when(pathfinder.findShortestWay(army1.getCurrentRegion(), region2,player1,false)).thenReturn(movement.getPath());
+        when(pathfinder.findShortestWay(army1.getCurrentRegion(), region2, player1, false)).thenReturn(movement.getPath());
         when(mockClaimBuildService.getClaimBuildByName(claimBuild1.getName())).thenReturn(claimBuild1);
         when(mockClaimBuildService.getClaimBuildByName(claimBuild2.getName())).thenReturn(claimBuild2);
         when(mockClaimBuildService.getClaimBuildByName(claimBuild3.getName())).thenReturn(claimBuild3);
-        when(mockWarRepository.queryActiveInitialWarBetween(any(),any())).thenReturn(Optional.of(war));
-        when(mockWarRepository.queryWarsBetweenFactions(any(),any(), any())).thenReturn(Set.of(war));
+        when(mockWarRepository.queryActiveInitialWarBetween(any(), any())).thenReturn(Optional.of(war));
+        when(mockWarRepository.queryWarsBetweenFactions(any(), any(), any())).thenReturn(Set.of(war));
         when(mockBattleRepository.save(any())).thenAnswer(i -> i.getArguments()[0]);
         when(mockArmyService.getArmyByName("Knights of Gondor")).thenReturn(army1);
         when(mockArmyService.getArmyByName("Knights of Isengard")).thenReturn(army2);
@@ -172,12 +166,12 @@ public class BattleServiceTest {
     }
 
     @Test
-    void ensureCreateBattleWorksWhenPlayerBoundToArmy(){
+    void ensureCreateBattleWorksWhenPlayerBoundToArmy() {
         log.debug("Testing if createBattle works when player is not leader but bound to the army!");
 
         // Assign
         log.trace("Initializing player, rpchar, regions, army");
-        CreateBattleDto createBattleDto = new CreateBattleDto("1234","Battle of Gondor","Knights of Gondor","Knights of Isengard",true, null);
+        CreateBattleDto createBattleDto = new CreateBattleDto("1234", "Battle of Gondor", "Knights of Gondor", "Knights of Isengard", true, null);
 
         Battle newBattle = battleService.createBattle(createBattleDto);
         log.debug(newBattle.getName());
@@ -190,7 +184,7 @@ public class BattleServiceTest {
     }
 
     @Test
-    void ensureCreateBattleWorksWithClaimBuildBattle(){
+    void ensureCreateBattleWorksWithClaimBuildBattle() {
         log.debug("Testing if createBattle works when player is not leader but bound to the army!");
 
         // Assign
@@ -198,7 +192,7 @@ public class BattleServiceTest {
         claimBuild2.setStationedArmies(List.of(army2));
         army2.setStationedAt(claimBuild2);
         battleLocation = new BattleLocation(claimBuild2.getRegion(), false, claimBuild2);
-        CreateBattleDto createBattleDto = new CreateBattleDto("1234","Battle of Gondor","Knights of Gondor",null,false, claimBuild2.getName());
+        CreateBattleDto createBattleDto = new CreateBattleDto("1234", "Battle of Gondor", "Knights of Gondor", null, false, claimBuild2.getName());
 
         Battle newBattle = battleService.createBattle(createBattleDto);
         log.debug(newBattle.getName());
@@ -210,7 +204,7 @@ public class BattleServiceTest {
     }
 
     @Test
-    void ensureCreateBattleWorksWhenPlayerIsLeader(){
+    void ensureCreateBattleWorksWhenPlayerIsLeader() {
         log.debug("Testing if createBattle works when player is the faction leader but not bound to the army!");
         army1.setBoundTo(rpchar2);
         faction1.setLeader(player1);
@@ -225,12 +219,12 @@ public class BattleServiceTest {
     }
 
     @Test
-    void ensureCreateBattleWorksWhenDefendingArmyIsMovingButCanBeCaught(){
+    void ensureCreateBattleWorksWhenDefendingArmyIsMovingButCanBeCaught() {
         log.debug("Testing if createBattle works when defending army is moving but can be caught!");
 
         // Assign
         log.trace("Initializing player, rpchar, regions, army");
-        CreateBattleDto createBattleDto = new CreateBattleDto("1234","Battle of Gondor","Knights of Gondor","Knights of Isengard",true,"Aira");
+        CreateBattleDto createBattleDto = new CreateBattleDto("1234", "Battle of Gondor", "Knights of Gondor", "Knights of Isengard", true, "Aira");
 
         Battle newBattle = battleService.createBattle(createBattleDto);
         log.debug(newBattle.getName());
@@ -242,55 +236,55 @@ public class BattleServiceTest {
     }
 
     @Test
-    void ensureCreateBattleThrowsExceptionWhenPlayerNotBound(){
+    void ensureCreateBattleThrowsExceptionWhenPlayerNotBound() {
         //Player1 is not bound to attacking army, so they have no permission to create a battle
-        CreateBattleDto createBattleDto = new CreateBattleDto(player1.getDiscordID(),"Battle of Gondor",
-                "Knights of Isengard","Knights of Gondor",true,"Aira");
+        CreateBattleDto createBattleDto = new CreateBattleDto(player1.getDiscordID(), "Battle of Gondor",
+                "Knights of Isengard", "Knights of Gondor", true, "Aira");
 
-        var exception = assertThrows(ArmyServiceException.class, ()-> battleService.createBattle(createBattleDto));
+        var exception = assertThrows(ArmyServiceException.class, () -> battleService.createBattle(createBattleDto));
 
         assertThat(exception.getMessage()).isEqualTo(ArmyServiceException.noPermissionToPerformThisAction().getMessage());
     }
 
     @Test
-    void ensureCreateBattleThrowsNotEnoughHealthException(){
+    void ensureCreateBattleThrowsNotEnoughHealthException() {
         army1.setFreeTokens(0.0);
 
-        CreateBattleDto createBattleDto = new CreateBattleDto("1234","Battle of Gondor","Knights of Gondor","Knights of Isengard",true,"Aira");
+        CreateBattleDto createBattleDto = new CreateBattleDto("1234", "Battle of Gondor", "Knights of Gondor", "Knights of Isengard", true, "Aira");
 
-        var exception = assertThrows(BattleServiceException.class, ()-> battleService.createBattle(createBattleDto));
+        var exception = assertThrows(BattleServiceException.class, () -> battleService.createBattle(createBattleDto));
 
         assertThat(exception.getMessage()).contains("Army does not have enough health");
     }
 
     @Test
-    void ensureCreateBattleThrowsExceptionWhenDefendingArmyIsMovingAway(){
+    void ensureCreateBattleThrowsExceptionWhenDefendingArmyIsMovingAway() {
         log.debug("Testing if createBattle throws exception when defending army is moving away and cannot be caught!");
-        
+
         movement.setEndTime(movement.getStartTime().plusHours(22));
         movement.setReachesNextRegionAt(movement.getStartTime().plusHours(22));
         army2.getMovements().add(movement);
 
-        var exception = assertThrows(BattleServiceException.class, ()-> battleService.createBattle(createBattleDto));
+        var exception = assertThrows(BattleServiceException.class, () -> battleService.createBattle(createBattleDto));
 
         assertThat(exception.getMessage()).isEqualTo(BattleServiceException.defendingArmyIsMovingAway(army2).getMessage());
     }
 
     @Test
-    void ensureCreateBattleThrowsExceptionWhenFactionsNotAtWar(){
+    void ensureCreateBattleThrowsExceptionWhenFactionsNotAtWar() {
         log.debug("Testing if createBattle throws exception when factions are not at war!");
 
         war = null;
-        when(mockWarRepository.queryWarsBetweenFactions(any(),any(),any())).thenReturn(new HashSet<>());
+        when(mockWarRepository.queryWarsBetweenFactions(any(), any(), any())).thenReturn(new HashSet<>());
 
 
-        var exception = assertThrows(BattleServiceException.class, ()-> battleService.createBattle(createBattleDto));
+        var exception = assertThrows(BattleServiceException.class, () -> battleService.createBattle(createBattleDto));
 
         assertThat(exception.getMessage()).isEqualTo(BattleServiceException.factionsNotAtWar(faction1.getName(), faction2.getName()).getMessage());
     }
 
     @Test
-    void ensureCreateBattleThrowsExceptionWhenAttackingArmyIsMoving(){
+    void ensureCreateBattleThrowsExceptionWhenAttackingArmyIsMoving() {
         log.debug("Testing if createBattle throws exception when attacking army is moving!");
 
         movement.setArmy(army1);
@@ -298,20 +292,55 @@ public class BattleServiceTest {
         movements.add(movement);
         army1.setMovements(movements);
 
-        var exception = assertThrows(BattleServiceException.class, ()-> battleService.createBattle(createBattleDto));
+        var exception = assertThrows(BattleServiceException.class, () -> battleService.createBattle(createBattleDto));
 
         assertThat(exception.getMessage()).isEqualTo(BattleServiceException.attackingArmyHasAnotherMovement().getMessage());
     }
 
     @Test
-    void ensureCreateBattleThrowsExceptionWhenArmiesNotInSameRegion(){
+    void ensureCreateBattleThrowsExceptionWhenArmiesNotInSameRegion() {
         log.debug("Testing if createBattle throws exception when armies not in same region!");
 
         army1.setCurrentRegion(region1);
 
-        var exception = assertThrows(BattleServiceException.class, ()-> battleService.createBattle(createBattleDto));
+        var exception = assertThrows(BattleServiceException.class, () -> battleService.createBattle(createBattleDto));
 
         assertThat(exception.getMessage()).isEqualTo(BattleServiceException.notInSameRegion(army1, army2).getMessage());
+    }
+
+    @Test
+    void ensureIsArmyInBattleReturnsTrueWhenArmyIsInBattle() {
+        log.debug("Testing if isArmyInBattle returns true when army is in battle!");
+
+        // Mock findActiveBattleByArmyId to return a battle
+        Long armyId = army1.getId();
+        when(mockBattleRepository.findActiveBattleByArmyId(armyId)).thenReturn(battle);
+
+        assertThat(battleService.isArmyInActiveBattle(army1.getId())).isTrue();
+    }
+
+    @Test
+    void ensureIsArmyInBattleReturnsFalseWhenArmyIsNotInBattle() {
+        log.debug("Testing if isArmyInBattle returns false when army is not in battle!");
+
+        // Mock findActiveBattleByArmyId to return null
+        Long armyId = army1.getId();
+        when(mockBattleRepository.findActiveBattleByArmyId(armyId)).thenReturn(null);
+
+        assertThat(battleService.isArmyInActiveBattle(army1.getId())).isFalse();
+    }
+
+    @Test
+    void ensureCreateBattleThrowsExceptionWhenArmyIsAlreadyInBattle() {
+        log.debug("Testing if createBattle throws exception when army is already in battle!");
+
+        // Mock findActiveBattleByArmyId to return a non-null Battle object
+        Long armyId = army1.getId();
+        when(mockBattleRepository.findActiveBattleByArmyId(armyId)).thenReturn(battle);
+
+        var exception = assertThrows(BattleServiceException.class, () -> battleService.createBattle(createBattleDto));
+
+        assertThat(exception.getMessage()).isEqualTo(BattleServiceException.armyAlreadyInBattle(army1.getName()).getMessage());
     }
 
 }


### PR DESCRIPTION
ArmyService Enhancements: Added isArmyInActiveBattle method to check if an army is already in an active battle when it attempts to declare a new one.  

Repository Methods: Added methods in BattleRepository to retrieve active and past battles of an army:  
findActiveBattleByArmyId
findPastBattlesByArmyId

Battle Entity Update: Set the battlePhase attribute of the Battle entity to be enumerated for better type safety and clarity.  

Army Entity Update: Added currentBattle field in the Army entity to keep track of the battle the army is currently participating in, whether it is part of the defenders, has declared the battle, or is aiding until the battle concludes.